### PR TITLE
Add last-human-msg dashboard provider

### DIFF
--- a/.mise/tasks/provider
+++ b/.mise/tasks/provider
@@ -5,9 +5,7 @@
 set -eu
 
 NAME="$usage_name"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-PROVIDER="$REPO_DIR/scripts/providers/${NAME}.sh"
+PROVIDER="$MISE_CONFIG_ROOT/scripts/providers/${NAME}.sh"
 
 if [ ! -f "$PROVIDER" ]; then
   echo "Error: No provider '$NAME' (expected $PROVIDER)" >&2

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Run BATS tests"
+set -e
+ESCORT_ROOT="$MISE_CONFIG_ROOT" bats "$MISE_CONFIG_ROOT/test/"

--- a/catalog/session-timer.json
+++ b/catalog/session-timer.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c '# hookers:session-timer\nmkdir -p ~/.local/state/escort && date +%s > ~/.local/state/escort/session-start'"
+            "command": "bash -c '# hookers:session-timer\nSTATE_DIR=\"${XDG_STATE_HOME:-$HOME/.local/state}/escort\" && mkdir -p \"$STATE_DIR\" && date +%s > \"$STATE_DIR/session-start\"'"
           }
         ]
       }

--- a/scripts/lib/format-duration.sh
+++ b/scripts/lib/format-duration.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Format a duration in seconds as a human-readable string.
+# Usage: format_duration <seconds>
+# Output: "<1m", "3m", "1h12m", "2h"
+
+format_duration() {
+  local elapsed=$1
+
+  if [ "$elapsed" -lt 60 ]; then
+    echo "<1m"
+  elif [ "$elapsed" -lt 3600 ]; then
+    echo "$((elapsed / 60))m"
+  else
+    local h=$((elapsed / 3600))
+    local m=$(( (elapsed % 3600) / 60 ))
+    if [ "$m" -gt 0 ]; then
+      echo "${h}h${m}m"
+    else
+      echo "${h}h"
+    fi
+  fi
+}

--- a/scripts/providers/last-human-msg.sh
+++ b/scripts/providers/last-human-msg.sh
@@ -4,33 +4,22 @@
 # Runs on every UserPromptSubmit via the dashboard hook.
 # Output: "3m" or "1h12m" or "<1m"
 
+source "$MISE_CONFIG_ROOT/scripts/lib/format-duration.sh"
+
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/escort"
 STATE_FILE="$STATE_DIR/last-human-msg"
 
-mkdir -p "$(dirname "$STATE_FILE")"
+mkdir -p "$STATE_DIR"
 
 NOW=$(date +%s)
 
 # Read previous timestamp (if any)
 if [ -f "$STATE_FILE" ]; then
-  PREV=$(cat "$STATE_FILE")
+  read -r PREV < "$STATE_FILE"
 
   if [ -n "$PREV" ]; then
     ELAPSED=$((NOW - PREV))
-
-    if [ "$ELAPSED" -lt 60 ]; then
-      echo "<1m"
-    elif [ "$ELAPSED" -lt 3600 ]; then
-      echo "$((ELAPSED / 60))m"
-    else
-      H=$((ELAPSED / 3600))
-      M=$(( (ELAPSED % 3600) / 60 ))
-      if [ "$M" -gt 0 ]; then
-        echo "${H}h${M}m"
-      else
-        echo "${H}h"
-      fi
-    fi
+    format_duration "$ELAPSED"
   fi
 fi
 

--- a/scripts/providers/session-elapsed.sh
+++ b/scripts/providers/session-elapsed.sh
@@ -1,28 +1,18 @@
 #!/usr/bin/env bash
 # Dashboard provider: time since session started
-# Reads timestamp from ~/.local/state/escort/session-start
+# Reads timestamp from $XDG_STATE_HOME/escort/session-start
 # Written by the session-timer hook (catalog/session-timer.json)
 # Output: "47m" or "2h13m"
 
-STATE_FILE="${HOME}/.local/state/escort/session-start"
+source "$MISE_CONFIG_ROOT/scripts/lib/format-duration.sh"
+
+STATE_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/escort/session-start"
 [ ! -f "$STATE_FILE" ] && exit 0
 
-START=$(cat "$STATE_FILE")
+read -r START < "$STATE_FILE"
 [ -z "$START" ] && exit 0
 
 NOW=$(date +%s)
 ELAPSED=$((NOW - START))
 
-if [ "$ELAPSED" -lt 60 ]; then
-  echo "<1m"
-elif [ "$ELAPSED" -lt 3600 ]; then
-  echo "$((ELAPSED / 60))m"
-else
-  H=$((ELAPSED / 3600))
-  M=$(( (ELAPSED % 3600) / 60 ))
-  if [ "$M" -gt 0 ]; then
-    echo "${H}h${M}m"
-  else
-    echo "${H}h"
-  fi
-fi
+format_duration "$ELAPSED"

--- a/test/format-duration.bats
+++ b/test/format-duration.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+setup() {
+  load helpers
+}
+
+# ============ Basic formatting ============
+
+@test "format_duration: under 60s shows <1m" {
+  run format_duration 0
+  [ "$output" = "<1m" ]
+
+  run format_duration 30
+  [ "$output" = "<1m" ]
+
+  run format_duration 59
+  [ "$output" = "<1m" ]
+}
+
+@test "format_duration: exact minutes" {
+  run format_duration 60
+  [ "$output" = "1m" ]
+
+  run format_duration 300
+  [ "$output" = "5m" ]
+
+  run format_duration 3540
+  [ "$output" = "59m" ]
+}
+
+@test "format_duration: hours with minutes" {
+  run format_duration 3660
+  [ "$output" = "1h1m" ]
+
+  run format_duration 7920
+  [ "$output" = "2h12m" ]
+}
+
+@test "format_duration: exact hours (no minutes)" {
+  run format_duration 3600
+  [ "$output" = "1h" ]
+
+  run format_duration 7200
+  [ "$output" = "2h" ]
+}
+
+@test "format_duration: large values" {
+  run format_duration 86400
+  [ "$output" = "24h" ]
+
+  run format_duration 90060
+  [ "$output" = "25h1m" ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,0 +1,27 @@
+# Shared helpers for escort BATS tests
+#
+# ESCORT_ROOT must be set by the test runner (mise task).
+
+# Source the format-duration library
+source "$ESCORT_ROOT/scripts/lib/format-duration.sh"
+
+# Create an isolated state directory for testing providers
+# Sets: XDG_STATE_HOME (overridden for isolation)
+setup_test_state() {
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/xdg-state-$$"
+  mkdir -p "$XDG_STATE_HOME/escort"
+}
+
+# Write a timestamp to a state file
+# Usage: write_timestamp <filename> <epoch_seconds>
+write_timestamp() {
+  local filename="$1" epoch="$2"
+  echo "$epoch" > "$XDG_STATE_HOME/escort/$filename"
+}
+
+# Run a provider script with MISE_CONFIG_ROOT set
+# Usage: run_provider <provider_name>
+run_provider() {
+  local name="$1"
+  MISE_CONFIG_ROOT="$ESCORT_ROOT" bash "$ESCORT_ROOT/scripts/providers/${name}.sh"
+}

--- a/test/providers.bats
+++ b/test/providers.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+setup() {
+  load helpers
+  setup_test_state
+}
+
+# ============ last-human-msg ============
+
+@test "last-human-msg: no previous timestamp produces no output" {
+  run run_provider last-human-msg
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "last-human-msg: writes timestamp for next invocation" {
+  run_provider last-human-msg
+  [ -f "$XDG_STATE_HOME/escort/last-human-msg" ]
+  # File should contain a unix timestamp
+  [[ "$(cat "$XDG_STATE_HOME/escort/last-human-msg")" =~ ^[0-9]+$ ]]
+}
+
+@test "last-human-msg: shows delta from previous timestamp" {
+  local now
+  now=$(date +%s)
+  write_timestamp "last-human-msg" $((now - 300))
+
+  run run_provider last-human-msg
+  [ "$status" -eq 0 ]
+  [ "$output" = "5m" ]
+}
+
+@test "last-human-msg: short gap shows <1m" {
+  local now
+  now=$(date +%s)
+  write_timestamp "last-human-msg" $((now - 10))
+
+  run run_provider last-human-msg
+  [ "$status" -eq 0 ]
+  [ "$output" = "<1m" ]
+}
+
+@test "last-human-msg: long gap shows hours" {
+  local now
+  now=$(date +%s)
+  write_timestamp "last-human-msg" $((now - 7200))
+
+  run run_provider last-human-msg
+  [ "$status" -eq 0 ]
+  [ "$output" = "2h" ]
+}
+
+# ============ session-elapsed ============
+
+@test "session-elapsed: no state file exits cleanly" {
+  run run_provider session-elapsed
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-elapsed: shows time since session start" {
+  local now
+  now=$(date +%s)
+  write_timestamp "session-start" $((now - 2700))
+
+  run run_provider session-elapsed
+  [ "$status" -eq 0 ]
+  [ "$output" = "45m" ]
+}
+
+@test "session-elapsed: empty state file exits cleanly" {
+  echo "" > "$XDG_STATE_HOME/escort/session-start"
+
+  run run_provider session-elapsed
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ============ XDG compliance ============
+
+@test "last-human-msg: respects XDG_STATE_HOME" {
+  run_provider last-human-msg
+  [ -f "$XDG_STATE_HOME/escort/last-human-msg" ]
+  # Should NOT be in the default location
+  [ ! -f "$HOME/.local/state/escort/last-human-msg" ] || \
+    [ "$XDG_STATE_HOME" != "$HOME/.local/state" ]
+}
+
+@test "session-elapsed: respects XDG_STATE_HOME" {
+  local now
+  now=$(date +%s)
+  write_timestamp "session-start" $((now - 60))
+
+  run run_provider session-elapsed
+  [ "$status" -eq 0 ]
+  [ "$output" = "1m" ]
+}


### PR DESCRIPTION
## Summary

- New dashboard provider showing time since the human's previous message (e.g., `3m`, `1h12m`, `<1m`)
- Helps agents gauge conversation pace — short gap means active conversation, long gap means human context-switched
- Self-updating: reads previous timestamp, computes delta, writes current timestamp. No separate hook needed
- Uses `XDG_STATE_HOME` (falling back to `~/.local/state`) — first escort provider to use XDG paths

### Dashboard config addition

```json
{"label": "last-msg", "command": "escort provider last-human-msg"}
```

Closes #5 (partially — `idle-since` metric is a follow-up)

## Test plan

- [ ] Add to `~/.config/hookers/dashboard.json` and verify it appears in the dashboard
- [ ] First message of session: no output (no previous timestamp) — item silently skipped
- [ ] Subsequent messages: shows delta from previous message
- [ ] Long gap (step away, come back): shows accurate gap duration
- [ ] Verify XDG_STATE_HOME is respected when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)