### PR TITLE
feat: extract timer task, update catalog to new manifest format

### DIFF
--- a/.mise/tasks/provider
+++ b/.mise/tasks/provider
@@ -2,7 +2,7 @@
 #MISE description="Run a dashboard data provider"
 #USAGE arg "<name>" help="Provider name (e.g., mail-breakdown, open-prs, active-agents)"
 
-set -eu
+set -euo pipefail
 
 NAME="$usage_name"
 PROVIDER="$MISE_CONFIG_ROOT/scripts/providers/${NAME}.sh"

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 #MISE description="Run BATS tests"
-set -e
+set -euo pipefail
 ESCORT_ROOT="$MISE_CONFIG_ROOT" bats "$MISE_CONFIG_ROOT/test/"

--- a/.mise/tasks/timer
+++ b/.mise/tasks/timer
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#MISE description="Record session timing events"
+#USAGE arg "<action>" help="Timer action: start or stop"
+
+set -euo pipefail
+
+ACTION="$usage_action"
+STATE_DIR="${ESCORT_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/escort}"
+
+mkdir -p "$STATE_DIR"
+
+case "$ACTION" in
+  start)
+    date +%s > "$STATE_DIR/session-start"
+    ;;
+  stop)
+    date +%s > "$STATE_DIR/agent-stop"
+    ;;
+  *)
+    echo "Error: Unknown action '$ACTION' (expected: start, stop)" >&2
+    exit 1
+    ;;
+esac

--- a/catalog/agent-stop.json
+++ b/catalog/agent-stop.json
@@ -1,17 +1,7 @@
 {
   "name": "agent-stop",
   "description": "Record when the agent finishes responding, for the idle-since provider",
-  "hooks": {
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c '# hookers:agent-stop\nSTATE_DIR=\"${XDG_STATE_HOME:-$HOME/.local/state}/escort\" && mkdir -p \"$STATE_DIR\" && date +%s > \"$STATE_DIR/agent-stop\"'"
-          }
-        ]
-      }
-    ]
-  }
+  "on": "agent-stop",
+  "action": "run",
+  "command": "escort timer stop"
 }

--- a/catalog/session-timer.json
+++ b/catalog/session-timer.json
@@ -1,17 +1,7 @@
 {
   "name": "session-timer",
   "description": "Record session start time for the session-elapsed provider",
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash -c '# hookers:session-timer\nSTATE_DIR=\"${XDG_STATE_HOME:-$HOME/.local/state}/escort\" && mkdir -p \"$STATE_DIR\" && date +%s > \"$STATE_DIR/session-start\"'"
-          }
-        ]
-      }
-    ]
-  }
+  "on": "session-start",
+  "action": "run",
+  "command": "escort timer start"
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,7 @@
+[settings]
+quiet = true
+task_output = "interleave"
+
 [tools]
 jq = "latest"
 bats = "1.13.0"

--- a/scripts/lib/format-duration.sh
+++ b/scripts/lib/format-duration.sh
@@ -2,6 +2,7 @@
 # Format a duration in seconds as a human-readable string.
 # Usage: format_duration <seconds>
 # Output: "<1m", "3m", "1h12m", "2h"
+set -euo pipefail
 
 format_duration() {
   local elapsed=$1

--- a/scripts/providers/active-agents.sh
+++ b/scripts/providers/active-agents.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Dashboard provider: agents currently running (in-progress fold workflow runs)
 # Output: "k7r2 rho c0da" or empty if none
+set -euo pipefail
 
 RUNS=$(gh api /repos/ricon-family/fold/actions/runs?status=in_progress --jq '.workflow_runs[].triggering_actor.login' 2>/dev/null || true)
 [ -z "$RUNS" ] && exit 0

--- a/scripts/providers/ci-status.sh
+++ b/scripts/providers/ci-status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Dashboard provider: CI status for current repo's default branch
 # Output: "pass", "fail", "running", or empty if not in a repo
+set -euo pipefail
 
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)
 [ -z "$REPO" ] && exit 0

--- a/scripts/providers/idle-since.sh
+++ b/scripts/providers/idle-since.sh
@@ -3,6 +3,7 @@
 # Reads timestamp written by the Stop hook (agent finished responding).
 # On each UserPromptSubmit, shows how long the agent was waiting.
 # Output: "3m" or "1h12m" or "<1m"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/scripts/lib/format-duration.sh"
 

--- a/scripts/providers/last-human-msg.sh
+++ b/scripts/providers/last-human-msg.sh
@@ -3,6 +3,7 @@
 # Self-updating: reads previous timestamp, outputs delta, writes current timestamp.
 # Runs on every UserPromptSubmit via the dashboard hook.
 # Output: "3m" or "1h12m" or "<1m"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/scripts/lib/format-duration.sh"
 

--- a/scripts/providers/mail-breakdown.sh
+++ b/scripts/providers/mail-breakdown.sh
@@ -4,6 +4,7 @@
 # Agent: *@ricon.family senders
 # GitHub: *-ricon senders (notification bots)
 # Human: everything else
+set -euo pipefail
 
 MAIL=$(shimmer email:list -n 200 2>/dev/null | grep ' \*' || true)
 [ -z "$MAIL" ] && exit 0

--- a/scripts/providers/open-prs.sh
+++ b/scripts/providers/open-prs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Dashboard provider: your open PRs + PRs requesting your review
 # Output: "3 open 1 review" or "3 open" or "1 review"
+set -euo pipefail
 
 OPEN=$(gh search prs --state=open --author=@me --json number --jq 'length' 2>/dev/null || echo "")
 REVIEW=$(gh search prs --state=open --review-requested=@me --json number --jq 'length' 2>/dev/null || echo "")

--- a/scripts/providers/session-elapsed.sh
+++ b/scripts/providers/session-elapsed.sh
@@ -3,6 +3,7 @@
 # Reads timestamp from $XDG_STATE_HOME/escort/session-start
 # Written by the session-timer hook (catalog/session-timer.json)
 # Output: "47m" or "2h13m"
+set -euo pipefail
 
 source "$MISE_CONFIG_ROOT/scripts/lib/format-duration.sh"
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -2,6 +2,11 @@
 #
 # ESCORT_ROOT must be set by the test runner (mise task).
 
+if [ -z "${ESCORT_ROOT:-}" ]; then
+  echo "ESCORT_ROOT not set — run tests via: mise run test" >&2
+  exit 1
+fi
+
 # Source the format-duration library
 source "$ESCORT_ROOT/scripts/lib/format-duration.sh"
 

--- a/test/timer.bats
+++ b/test/timer.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  if [ -z "${ESCORT_ROOT:-}" ]; then
+    echo "ESCORT_ROOT not set — run tests via: mise run test" >&2
+    exit 1
+  fi
+  TEST_DIR="$(mktemp -d)"
+  export ESCORT_STATE_DIR="$TEST_DIR/escort"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+escort_timer() {
+  cd "$ESCORT_ROOT" && mise run -q timer "$@"
+}
+export -f escort_timer
+
+@test "timer start creates session-start file" {
+  run escort_timer start
+  [ "$status" -eq 0 ]
+  [ -f "$ESCORT_STATE_DIR/session-start" ]
+  CONTENT=$(cat "$ESCORT_STATE_DIR/session-start")
+  [[ "$CONTENT" =~ ^[0-9]+$ ]]
+}
+
+@test "timer stop creates agent-stop file" {
+  run escort_timer stop
+  [ "$status" -eq 0 ]
+  [ -f "$ESCORT_STATE_DIR/agent-stop" ]
+  CONTENT=$(cat "$ESCORT_STATE_DIR/agent-stop")
+  [[ "$CONTENT" =~ ^[0-9]+$ ]]
+}
+
+@test "timer rejects unknown action" {
+  run escort_timer invalid
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown action"* ]]
+}
+
+@test "timer start is idempotent" {
+  escort_timer start
+  FIRST=$(cat "$ESCORT_STATE_DIR/session-start")
+
+  sleep 1
+  escort_timer start
+  SECOND=$(cat "$ESCORT_STATE_DIR/session-start")
+
+  [ "$SECOND" -ge "$FIRST" ]
+}


### PR DESCRIPTION
## Summary

Extract inline bash from catalog entries into a proper mise task, and update catalog entries to hookers' new manifest format.

### Timer task

New `escort timer <action>` task replaces the inline bash that was embedded in catalog JSON:

```bash
escort timer start   # writes session-start timestamp
escort timer stop    # writes agent-stop timestamp
```

Clean, testable, and matches the convention that hook commands are CLI invocations.

### Catalog format

Updated to hookers' new flat manifest format:

```json
{
  "name": "session-timer",
  "on": "session-start",
  "action": "run",
  "command": "escort timer start"
}
```

Companion to KnickKnackLabs/hookers#18.

### Tests

19 passing (15 existing + 4 new timer tests)