### PR TITLE
Use emails CLI instead of shimmer email:list

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,10 @@
 quiet = true
 task_output = "interleave"
 
+[plugins]
+shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
+
 [tools]
 jq = "latest"
 bats = "1.13.0"
+"shiv:emails" = "0.1.0"

--- a/scripts/providers/mail-breakdown.sh
+++ b/scripts/providers/mail-breakdown.sh
@@ -6,7 +6,7 @@
 # Human: everything else
 set -euo pipefail
 
-MAIL=$(shimmer email:list -n 200 2>/dev/null | grep ' \*' || true)
+MAIL=$(emails list -n 200 2>/dev/null | grep ' \*' || true)
 [ -z "$MAIL" ] && exit 0
 
 HUMAN=0


### PR DESCRIPTION
Dashboard provider updated: `shimmer email:list` → `emails list`. Part of the shimmer email extraction.