### PR TITLE
feat: use chat unread for bulk unread count

### DIFF
--- a/scripts/providers/unread-chat.sh
+++ b/scripts/providers/unread-chat.sh
@@ -7,16 +7,5 @@ set -euo pipefail
 command -v chat &>/dev/null || exit 0
 [ -z "${CHAT_IDENTITY:-}" ] && exit 0
 
-CHANNELS=$(chat list --json 2>/dev/null) || exit 0
-[ -z "$CHANNELS" ] || [ "$CHANNELS" = "[]" ] && exit 0
-
-TOTAL=0
-while IFS= read -r name; do
-  [ -z "$name" ] && continue
-  COUNT=$(chat read --peek --json "$name" 2>/dev/null | jq 'length' 2>/dev/null) || continue
-  TOTAL=$((TOTAL + COUNT))
-done < <(echo "$CHANNELS" | jq -r '.[].name')
-
-[ "$TOTAL" -eq 0 ] && exit 0
-
-echo "$TOTAL"
+# Use bulk unread command (single invocation, parallel internally)
+chat unread 2>/dev/null || exit 0


### PR DESCRIPTION
Simplifies the `unread-chat` provider to a single `chat unread` call instead of looping over channels. Reduces provider time from ~2s to ~500ms.

**Depends on:** KnickKnackLabs/chat#26