### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
+  MISE_JOBS: 1
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+        with:
+          install: true
+
+      - name: Run tests
+        run: mise run test

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,5 @@
 [settings]
+experimental = true
 quiet = true
 task_output = "interleave"
 


### PR DESCRIPTION
## Summary
- add the standard KKL GitHub Actions test workflow
- run `mise run test` on Ubuntu and macOS

## Verification
- `mise run test`
- `CALLER_PWD="$PWD" mise run -q --cd ~/agents/x1f9/codebase lint:github-actions "$PWD"`