### PR TITLE
Add session neighborhood dashboard provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Know what's happening without asking.
 
 ![shell: bash](https://img.shields.io/badge/shell-bash-4EAA25?style=flat&logo=gnubash&logoColor=white)
 [![runtime: mise](https://img.shields.io/badge/runtime-mise-7c3aed?style=flat)](https://mise.jdx.dev)
-![providers: 5](https://img.shields.io/badge/providers-5-blue?style=flat)
+![providers: 10](https://img.shields.io/badge/providers-10-blue?style=flat)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=flat)](LICENSE)
 
 </div>
@@ -61,6 +61,10 @@ Or add individual providers to your existing config:
       "command": "escort provider session-elapsed"
     },
     {
+      "label": "sessions",
+      "command": "escort provider session-neighborhood"
+    },
+    {
       "label": "ci",
       "command": "escort provider ci-status"
     }
@@ -70,20 +74,25 @@ Or add individual providers to your existing config:
 
 ## Providers
 
-| Provider | Description | Example output |
-| --- | --- | --- |
-| `active-agents` | agents currently running (in-progress fold workflow runs) | `k7r2 rho c0da or empty if none` |
-| `ci-status` | CI status for current repo's default branch | `pass, fail, running, or empty if not in a repo` |
-| `mail-breakdown` | unread mail breakdown by source | `2h 8a 1g (human, agent, github)` |
-| `open-prs` | your open PRs + PRs requesting your review | `3 open 1 review or 3 open or 1 review` |
-| `session-elapsed` | time since session started | `47m or 2h13m` |
+| Provider               | Description                                                         | Example output                                   |
+| ---------------------- | ------------------------------------------------------------------- | ------------------------------------------------ |
+| `active-agents`        | agents currently running (in-progress fold workflow runs)           | `k7r2 rho c0da or empty if none`                 |
+| `ci-status`            | CI status for current repo's default branch                         | `pass, fail, running, or empty if not in a repo` |
+| `hostname`             | short hostname                                                      | `macbook-pro or similar`                         |
+| `idle-since`           | time the agent has been idle (waiting for human input)              | `3m or 1h12m or <1m`                             |
+| `last-human-msg`       | time since previous human message                                   | `3m or 1h12m or <1m`                             |
+| `mail-breakdown`       | unread mail breakdown by source                                     | `2h 8a 1g (human, agent, github)`                |
+| `open-prs`             | your open PRs + PRs requesting your review                          | `3 open 1 review or 3 open or 1 review`          |
+| `session-elapsed`      | time since session started                                          | `47m or 2h13m`                                   |
+| `session-neighborhood` | active sibling sessions and recent sessions for this agent identity | `active 019e002f-d66b recent 019df64c-a7eb`      |
+| `unread-chat`          | total unread chat messages                                          | `19 or empty if no unread`                       |
 
 ## Example dashboard
 
 With all providers enabled, your dashboard looks like:
 
 ```
-[dashboard] mail: 8h 82a 3g | prs: 5 open 1 review | agents: k7r2 rho | ci: pass | elapsed: 47m | branch: main | gh-token: 5d
+[dashboard] mail: 8h 82a 3g | prs: 5 open 1 review | agents: k7r2 rho | ci: pass | elapsed: 47m | sessions: active 019e002f-d66b recent 019df64c-a7eb | branch: main | gh-token: 5d
 ```
 
 This fires on every prompt via hookers' `UserPromptSubmit` hook. Providers run in parallel — total latency is bounded by the slowest provider (~850ms worst case).

--- a/README.tsx
+++ b/README.tsx
@@ -96,6 +96,7 @@ cp $(shiv which escort)/examples/dashboard.json ~/.config/hookers/dashboard.json
     { label: "prs", command: "escort provider open-prs" },
     { label: "agents", command: "escort provider active-agents" },
     { label: "elapsed", command: "escort provider session-elapsed" },
+    { label: "sessions", command: "escort provider session-neighborhood" },
     { label: "ci", command: "escort provider ci-status" },
   ],
 }, null, 2)}</CodeBlock>
@@ -123,7 +124,7 @@ cp $(shiv which escort)/examples/dashboard.json ~/.config/hookers/dashboard.json
         With all providers enabled, your dashboard looks like:
       </Paragraph>
 
-      <CodeBlock>{`[dashboard] mail: 8h 82a 3g | prs: 5 open 1 review | agents: k7r2 rho | ci: pass | elapsed: 47m | branch: main | gh-token: 5d`}</CodeBlock>
+      <CodeBlock>{`[dashboard] mail: 8h 82a 3g | prs: 5 open 1 review | agents: k7r2 rho | ci: pass | elapsed: 47m | sessions: active 019e002f-d66b recent 019df64c-a7eb | branch: main | gh-token: 5d`}</CodeBlock>
 
       <Paragraph>
         This fires on every prompt via hookers' <Code>UserPromptSubmit</Code> hook.

--- a/examples/dashboard.json
+++ b/examples/dashboard.json
@@ -6,6 +6,7 @@
     {"label": "chat", "command": "escort provider unread-chat"},
     {"label": "ci", "command": "escort provider ci-status"},
     {"label": "elapsed", "command": "escort provider session-elapsed"},
+    {"label": "sessions", "command": "escort provider session-neighborhood"},
     {"label": "branch", "command": "hookers provider git-branch"},
     {"label": "gh-token", "command": "hookers provider gh-token-expiry"}
   ]

--- a/scripts/providers/session-neighborhood.sh
+++ b/scripts/providers/session-neighborhood.sh
@@ -8,7 +8,7 @@ SESSION_ID="${HOOKERS_SESSION_ID:-}"
 
 IDENTITY="${CHAT_IDENTITY:-${GIT_AUTHOR_NAME:-default}}"
 # Keep identity safe as a directory name while preserving readability.
-IDENTITY_SAFE=$(printf '%s' "$IDENTITY" | tr -c 'A-Za-z0-9._-@' '_')
+IDENTITY_SAFE=$(printf '%s' "$IDENTITY" | sed 's/[^A-Za-z0-9._@-]/_/g')
 
 STATE_ROOT="${ESCORT_SESSION_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/escort/sessions}"
 IDENTITY_DIR="$STATE_ROOT/$IDENTITY_SAFE"

--- a/scripts/providers/session-neighborhood.sh
+++ b/scripts/providers/session-neighborhood.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Dashboard provider: active sibling sessions and recent sessions for this agent identity
+# Output: active 019e002f-d66b recent 019df64c-a7eb
+set -euo pipefail
+
+SESSION_ID="${HOOKERS_SESSION_ID:-}"
+[ -z "$SESSION_ID" ] && exit 0
+
+IDENTITY="${CHAT_IDENTITY:-${GIT_AUTHOR_NAME:-default}}"
+# Keep identity safe as a directory name while preserving readability.
+IDENTITY_SAFE=$(printf '%s' "$IDENTITY" | tr -c 'A-Za-z0-9._-@' '_')
+
+STATE_ROOT="${ESCORT_SESSION_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/escort/sessions}"
+IDENTITY_DIR="$STATE_ROOT/$IDENTITY_SAFE"
+mkdir -p "$IDENTITY_DIR"
+
+NOW=$(date +%s)
+ACTIVE_TTL="${ESCORT_SESSION_ACTIVE_TTL:-1800}"
+RECENT_LIMIT="${ESCORT_SESSION_RECENT_LIMIT:-1}"
+PREFIX_LEN="${ESCORT_SESSION_ID_PREFIX_LEN:-13}"
+CWD_VALUE="${HOOKERS_CWD:-${PWD:-}}"
+CURRENT_FILE="$IDENTITY_DIR/$SESSION_ID.json"
+
+FIRST_SEEN="$NOW"
+if [ -f "$CURRENT_FILE" ]; then
+  existing_first=$(jq -r '.first_seen_at // empty' "$CURRENT_FILE" 2>/dev/null || true)
+  if [ -n "$existing_first" ]; then
+    FIRST_SEEN="$existing_first"
+  fi
+fi
+
+TMP_FILE="$CURRENT_FILE.tmp.$$"
+jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg cwd "$CWD_VALUE" \
+  --argjson first_seen_at "$FIRST_SEEN" \
+  --argjson last_seen_at "$NOW" \
+  '{session_id: $session_id, first_seen_at: $first_seen_at, last_seen_at: $last_seen_at, cwd: $cwd}' \
+  > "$TMP_FILE"
+mv "$TMP_FILE" "$CURRENT_FILE"
+
+ACTIVE_FILE=$(mktemp)
+RECENT_FILE=$(mktemp)
+trap 'rm -f "$ACTIVE_FILE" "$RECENT_FILE"' EXIT
+
+for f in "$IDENTITY_DIR"/*.json; do
+  [ -f "$f" ] || continue
+
+  sid=$(jq -r '.session_id // empty' "$f" 2>/dev/null || true)
+  last_seen=$(jq -r '.last_seen_at // empty' "$f" 2>/dev/null || true)
+
+  [ -z "$sid" ] && continue
+  [ -z "$last_seen" ] && continue
+  [ "$sid" = "$SESSION_ID" ] && continue
+  case "$last_seen" in
+    *[!0-9]* ) continue ;;
+  esac
+
+  short_sid=$(printf '%s' "$sid" | cut -c "1-${PREFIX_LEN}")
+  age=$((NOW - last_seen))
+  if [ "$age" -le "$ACTIVE_TTL" ]; then
+    printf '%s %s\n' "$last_seen" "$short_sid" >> "$ACTIVE_FILE"
+  else
+    printf '%s %s\n' "$last_seen" "$short_sid" >> "$RECENT_FILE"
+  fi
+done
+
+OUT=""
+if [ -s "$ACTIVE_FILE" ]; then
+  active=$(sort -nr "$ACTIVE_FILE" | awk '{print $2}' | paste -sd ' ' -)
+  if [ -n "$active" ]; then
+    OUT="active $active"
+  fi
+fi
+
+if [ -s "$RECENT_FILE" ] && [ "$RECENT_LIMIT" -gt 0 ]; then
+  recent=$(sort -nr "$RECENT_FILE" | awk '{print $2}' | head -n "$RECENT_LIMIT" | paste -sd ' ' -)
+  if [ -n "$recent" ]; then
+    if [ -n "$OUT" ]; then
+      OUT="$OUT recent $recent"
+    else
+      OUT="recent $recent"
+    fi
+  fi
+fi
+
+[ -n "$OUT" ] && echo "$OUT"
+exit 0

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -32,3 +32,18 @@ write_timestamp() {
   local filename="$1" epoch="$2"
   echo "$epoch" > "$XDG_STATE_HOME/escort/$filename"
 }
+
+# Write a session-neighborhood heartbeat fixture
+# Usage: write_session <identity> <session_id> <first_seen> <last_seen> [cwd]
+write_session() {
+  local identity="$1" session_id="$2" first_seen="$3" last_seen="$4" cwd="${5:-/tmp/test-workspace}"
+  local dir="$XDG_STATE_HOME/escort/sessions/$identity"
+  mkdir -p "$dir"
+  jq -n \
+    --arg session_id "$session_id" \
+    --arg cwd "$cwd" \
+    --argjson first_seen_at "$first_seen" \
+    --argjson last_seen_at "$last_seen" \
+    '{session_id: $session_id, first_seen_at: $first_seen_at, last_seen_at: $last_seen_at, cwd: $cwd}' \
+    > "$dir/$session_id.json"
+}

--- a/test/providers.bats
+++ b/test/providers.bats
@@ -76,6 +76,96 @@ setup() {
   [ -z "$output" ]
 }
 
+# ============ session-neighborhood ============
+
+@test "session-neighborhood: no HOOKERS_SESSION_ID exits cleanly" {
+  unset HOOKERS_SESSION_ID
+  run escort provider session-neighborhood
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-neighborhood: first session writes heartbeat and shows no output" {
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  HOOKERS_CWD=/tmp/current \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ -f "$XDG_STATE_HOME/escort/sessions/zeke/aaaaaaaa-aaaa-7000-8000-000000000001.json" ]
+  [ "$(jq -r '.session_id' "$XDG_STATE_HOME/escort/sessions/zeke/aaaaaaaa-aaaa-7000-8000-000000000001.json")" = "aaaaaaaa-aaaa-7000-8000-000000000001" ]
+  [ "$(jq -r '.cwd' "$XDG_STATE_HOME/escort/sessions/zeke/aaaaaaaa-aaaa-7000-8000-000000000001.json")" = "/tmp/current" ]
+}
+
+@test "session-neighborhood: shows recent inactive session" {
+  local now
+  now=$(date +%s)
+  write_session zeke "bbbbbbbb-bbbb-7000-8000-000000000002" $((now - 7200)) $((now - 3600))
+
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "recent bbbbbbbb-bbbb" ]
+}
+
+@test "session-neighborhood: shows active sibling before recent sessions" {
+  local now
+  now=$(date +%s)
+  write_session zeke "bbbbbbbb-bbbb-7000-8000-000000000002" $((now - 7200)) $((now - 3600))
+  write_session zeke "cccccccc-cccc-7000-8000-000000000003" $((now - 120)) $((now - 60))
+
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "active cccccccc-cccc recent bbbbbbbb-bbbb" ]
+}
+
+@test "session-neighborhood: excludes current session" {
+  local now
+  now=$(date +%s)
+  write_session zeke "aaaaaaaa-aaaa-7000-8000-000000000001" $((now - 7200)) $((now - 60))
+
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-neighborhood: scopes sessions by identity" {
+  local now
+  now=$(date +%s)
+  write_session ikma "bbbbbbbb-bbbb-7000-8000-000000000002" $((now - 7200)) $((now - 3600))
+
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "session-neighborhood: respects recent limit" {
+  local now
+  now=$(date +%s)
+  write_session zeke "bbbbbbbb-bbbb-7000-8000-000000000002" $((now - 7200)) $((now - 3600))
+  write_session zeke "cccccccc-cccc-7000-8000-000000000003" $((now - 7200)) $((now - 3500))
+
+  HOOKERS_SESSION_ID="aaaaaaaa-aaaa-7000-8000-000000000001" \
+  CHAT_IDENTITY=zeke \
+  ESCORT_SESSION_RECENT_LIMIT=2 \
+  run escort provider session-neighborhood
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "recent cccccccc-cccc bbbbbbbb-bbbb" ]
+}
+
 # ============ unread-chat ============
 
 @test "unread-chat: no chat CLI exits cleanly" {


### PR DESCRIPTION
## Summary

- add `escort provider session-neighborhood`
- track per-agent/per-session heartbeat files keyed by `HOOKERS_SESSION_ID`
- render active sibling sessions and recent non-current sessions as short ID prefixes
- include the provider in the example dashboard and regenerated README

Closes #8.

## Test plan

- `mise run test`
- manual smoke: seeded a prior heartbeat and ran `escort provider session-neighborhood`, producing `recent 019df64c-a7eb`
